### PR TITLE
refactor: use mpsc::Sender instead of Arc<Mutex>>

### DIFF
--- a/crates/nu-cli/src/commands/commandline/edit.rs
+++ b/crates/nu-cli/src/commands/commandline/edit.rs
@@ -65,8 +65,10 @@ impl Command for SubCommand {
             repl.cursor_pos = repl.buffer.len();
         }
         if call.has_flag(engine_state, stack, "accept")? {
-            if let Ok(mut queue) = engine_state.reedline_event_queue.lock() {
-                queue.push(ReedlineEvent::Enter);
+            if let Some(sender) = &engine_state.reedline_event_sender {
+                if let Err(e) = sender.send(ReedlineEvent::Submit) {
+                    log::warn!("Failed to send submit: {e:?}");
+                }
             }
         }
         Ok(Value::nothing(call.head).into_pipeline_data())

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -234,8 +234,9 @@ fn get_line_editor(
     use_color: bool,
 ) -> Result<Reedline> {
     let mut start_time = std::time::Instant::now();
-    let mut line_editor =
-        Reedline::create().with_reedline_event_queue(engine_state.reedline_event_queue.clone());
+    let mut line_editor = Reedline::create();
+
+    engine_state.reedline_event_sender = Some(line_editor.reedline_event_sender.clone());
 
     // Now that reedline is created, get the history session id and store it in engine_state
     store_history_id_in_engine(engine_state, &line_editor);
@@ -388,7 +389,10 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     line_editor =
         add_menus(line_editor, engine_reference, &stack_arc, config).unwrap_or_else(|e| {
             report_error_new(engine_state, &e);
-            Reedline::create().with_reedline_event_queue(engine_state.reedline_event_queue.clone())
+
+            let line_editor = Reedline::create();
+            engine_state.reedline_event_sender = Some(line_editor.reedline_event_sender.clone());
+            line_editor
         });
 
     perf!("reedline adding menus", start_time, use_color);

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -21,6 +21,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicU32, Ordering},
+        mpsc::Sender,
         Arc, Mutex, MutexGuard, PoisonError,
     },
 };
@@ -110,7 +111,7 @@ pub struct EngineState {
     startup_time: i64,
     is_debugging: IsDebugging,
     pub debugger: Arc<Mutex<Box<dyn Debugger>>>,
-    pub reedline_event_queue: Arc<Mutex<Vec<ReedlineEvent>>>,
+    pub reedline_event_sender: Option<Sender<ReedlineEvent>>,
 }
 
 // The max number of compiled regexes to keep around in a LRU cache, arbitrarily chosen
@@ -180,7 +181,7 @@ impl EngineState {
             startup_time: -1,
             is_debugging: IsDebugging::new(false),
             debugger: Arc::new(Mutex::new(Box::new(NoopDebugger))),
-            reedline_event_queue: Arc::new(vec![].into()),
+            reedline_event_sender: None,
         }
     }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
